### PR TITLE
Add polygon drawing tools to define custom areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,16 @@
                         <i class="fas fa-calculator"></i> Yerleştirmeyi Hesapla
                     </button>
                 </div>
+
+                <div class="polygon-drawing">
+                    <div class="drawing-controls">
+                        <button id="addPointBtn" class="btn btn-secondary">Nokta Ekle</button>
+                        <button id="finishDrawingBtn" class="btn btn-secondary">Çizimi Bitir</button>
+                        <button id="confirmPolygonBtn" class="btn btn-primary" style="display: none;">Tamam</button>
+                        <div id="segmentInfo" class="segment-info"></div>
+                    </div>
+                    <canvas id="polygonCanvas" width="400" height="400"></canvas>
+                </div>
             </section>
 
             <!-- Sonuçlar Bölümü -->


### PR DESCRIPTION
## Summary
- allow polygon drawing on a dedicated canvas and track segment lengths
- compute polygon area on confirmation and store in state
- add UI buttons for point adding, finishing, and confirming polygons

## Testing
- `node --check script.js && echo "syntax ok"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68904f8431908326963de689831ad8b2