### PR TITLE
Clean up HTML structure and remove patch remnants

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
             <!-- Kalıp Ekleme Bölümü -->
             <section class="panel-section">
                 <h2><i class="fas fa-plus-circle"></i> Kalıp Panelleri</h2>
-                
+
                 <div class="add-panel-form">
                     <div class="input-group">
                         <input type="number" id="panelWidth" placeholder="Genişlik (cm)" min="1" step="1">
@@ -42,14 +42,14 @@
             <!-- İnşaat Alanı Bölümü -->
             <section class="area-section">
                 <h2><i class="fas fa-ruler-combined"></i> İnşaat Alanı</h2>
-                
+
                 <div class="area-form">
                     <div class="input-group">
                         <input type="number" id="areaWidth" placeholder="Genişlik (m)" min="0.1" step="0.1">
                         <span class="input-separator">×</span>
                         <input type="number" id="areaHeight" placeholder="Yükseklik (m)" min="0.1" step="0.1">
                     </div>
-                    
+
                     <div class="options">
                         <label class="checkbox-label">
                             <input type="checkbox" id="allowRotation" checked>
@@ -57,12 +57,11 @@
                             Kalıpların dönmesine izin ver (90°)
                         </label>
                     </div>
-                    
+
                     <button id="calculateBtn" class="btn btn-success">
                         <i class="fas fa-calculator"></i> Yerleştirmeyi Hesapla
                     </button>
                 </div>
- codex/add-polygon-drawing-functionality
 
                 <div class="polygon-drawing">
                     <div class="drawing-controls">
@@ -73,80 +72,12 @@
                     </div>
                     <canvas id="polygonCanvas" width="400" height="400"></canvas>
                 </div>
-
-                diff --git a/index.html b/index.html
-index 4a165d918a2983fb1ce0f14a06f4ad260beacfb5..ee1686f7ae14572aa2c7843e0d6c077ba89a9122 100644
---- a/index.html
-+++ b/index.html
-@@ -40,50 +40,60 @@
-             </section>
- 
-             <!-- İnşaat Alanı Bölümü -->
-             <section class="area-section">
-                 <h2><i class="fas fa-ruler-combined"></i> İnşaat Alanı</h2>
-                 
-                 <div class="area-form">
-                     <div class="input-group">
-                         <input type="number" id="areaWidth" placeholder="Genişlik (m)" min="0.1" step="0.1">
-                         <span class="input-separator">×</span>
-                         <input type="number" id="areaHeight" placeholder="Yükseklik (m)" min="0.1" step="0.1">
-                     </div>
-                     
-                     <div class="options">
-                         <label class="checkbox-label">
-                             <input type="checkbox" id="allowRotation" checked>
-                             <span class="checkmark"></span>
-                             Kalıpların dönmesine izin ver (90°)
-                         </label>
-                     </div>
-                     
-                     <button id="calculateBtn" class="btn btn-success">
-                         <i class="fas fa-calculator"></i> Yerleştirmeyi Hesapla
-                     </button>
-                 </div>
-+
-+                <div class="polygon-drawing">
-+                    <div class="drawing-controls">
-+                        <button id="addPointBtn" class="btn btn-secondary">Nokta Ekle</button>
-+                        <button id="finishDrawingBtn" class="btn btn-secondary">Çizimi Bitir</button>
-+                        <button id="confirmPolygonBtn" class="btn btn-primary" style="display: none;">Tamam</button>
-+                        <div id="segmentInfo" class="segment-info"></div>
-+                    </div>
-+                    <canvas id="polygonCanvas" width="400" height="400"></canvas>
-+                </div>
-             </section>
- 
-             <!-- Sonuçlar Bölümü -->
-             <section class="results-section" id="resultsSection" style="display: none;">
-                 <h2><i class="fas fa-chart-bar"></i> Yerleştirme Sonuçları</h2>
-                 
-                 <div class="stats-grid">
-                     <div class="stat-card">
-                         <div class="stat-icon">
-                             <i class="fas fa-th-large"></i>
-                         </div>
-                         <div class="stat-content">
-                             <h3 id="usedPanelsCount">0</h3>
-                             <p>Kullanılan Panel</p>
-                         </div>
-                     </div>
-                     
-                     <div class="stat-card">
-                         <div class="stat-icon">
-                             <i class="fas fa-square"></i>
-                         </div>
-                         <div class="stat-content">
-                             <h3 id="remainingArea">0</h3>
-                             <p>Kalan Alan (m²)</p>
-                         </div>
-
- main
             </section>
 
             <!-- Sonuçlar Bölümü -->
             <section class="results-section" id="resultsSection" style="display: none;">
                 <h2><i class="fas fa-chart-bar"></i> Yerleştirme Sonuçları</h2>
-                
+
                 <div class="stats-grid">
                     <div class="stat-card">
                         <div class="stat-icon">
@@ -157,7 +88,7 @@ index 4a165d918a2983fb1ce0f14a06f4ad260beacfb5..ee1686f7ae14572aa2c7843e0d6c077b
                             <p>Kullanılan Panel</p>
                         </div>
                     </div>
-                    
+
                     <div class="stat-card">
                         <div class="stat-icon">
                             <i class="fas fa-square"></i>
@@ -167,7 +98,7 @@ index 4a165d918a2983fb1ce0f14a06f4ad260beacfb5..ee1686f7ae14572aa2c7843e0d6c077b
                             <p>Kalan Alan (m²)</p>
                         </div>
                     </div>
-                    
+
                     <div class="stat-card">
                         <div class="stat-icon">
                             <i class="fas fa-percentage"></i>


### PR DESCRIPTION
## Summary
- remove leftover patch lines and duplicated sections from index.html
- fix misplaced closing tags for area and results sections

## Testing
- `python - <<'PY'
from html.parser import HTMLParser
with open('index.html', 'r', encoding='utf-8') as f:
    data = f.read()
parser = HTMLParser()
parser.feed(data)
print('parsed successfully')
PY`
- `npm install -g vnu-jar` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890b08f71e08326b969a304129c26b5