### PR TITLE
Make polygon canvas responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                         <button id="confirmPolygonBtn" class="btn btn-primary" style="display: none;">Tamam</button>
                         <div id="segmentInfo" class="segment-info"></div>
                     </div>
-                    <canvas id="polygonCanvas" width="400" height="400"></canvas>
+                    <canvas id="polygonCanvas"></canvas>
                 </div>
             </section>
 

--- a/script.js
+++ b/script.js
@@ -83,6 +83,14 @@ class PanelPlacementApp {
     initPolygonDrawing() {
         this.polygonCanvas = this.elements.polygonCanvas;
         if (!this.polygonCanvas) return;
+        const setCanvasSize = () => {
+            const width = this.polygonCanvas.clientWidth;
+            this.polygonCanvas.width = width;
+            this.polygonCanvas.height = width;
+        };
+        setCanvasSize();
+        window.addEventListener('resize', setCanvasSize);
+
         this.polygonCtx = this.polygonCanvas.getContext('2d');
         this.isDrawingPolygon = false;
 

--- a/style.css
+++ b/style.css
@@ -157,6 +157,26 @@ input[type="number"]:focus {
     box-shadow: 0 3px 10px rgba(220, 53, 69, 0.4);
 }
 
+/* Polygon Drawing */
+.polygon-drawing canvas {
+    width: 100%;
+    height: auto;
+}
+
+.drawing-controls {
+    display: flex;
+    gap: 10px;
+}
+
+@media (max-width: 600px) {
+    .drawing-controls {
+        flex-direction: column;
+    }
+    .drawing-controls .btn {
+        width: 100%;
+    }
+}
+
 /* Panel Liste */
 .panels-list {
     margin-top: 20px;


### PR DESCRIPTION
## Summary
- make the polygon drawing canvas responsive by removing fixed dimensions and sizing via CSS/JS
- add responsive flex layout for drawing controls on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890b2fc13f88326b90c0660e489609d