### PR TITLE
Improve polygon canvas visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,6 +92,8 @@ class PanelPlacementApp {
         window.addEventListener('resize', setCanvasSize);
 
         this.polygonCtx = this.polygonCanvas.getContext('2d');
+        this.polygonCtx.lineWidth = 2;
+        this.polygonCtx.strokeStyle = '#000';
         this.isDrawingPolygon = false;
 
         this.elements.addPointBtn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -161,6 +161,8 @@ input[type="number"]:focus {
 .polygon-drawing canvas {
     width: 100%;
     height: auto;
+    border: 1px solid #ccc;
+    background: #fff;
 }
 
 .drawing-controls {


### PR DESCRIPTION
## Summary
- Add border and white background to polygon drawing canvas
- Set default line width and stroke color for polygon drawing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890bc7cf8ac8326b6377cd1170a7791