### PR TITLE
Handle scaled polygon inputs for placement and materials

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,13 @@
                         <button id="addPointBtn" class="btn btn-secondary">Nokta Ekle</button>
                         <button id="finishDrawingBtn" class="btn btn-secondary">Çizimi Bitir</button>
                         <button id="confirmPolygonBtn" class="btn btn-primary" style="display: none;">Tamam</button>
+                        <input
+                            type="number"
+                            id="drawingScale"
+                            placeholder="1 px kaç cm?"
+                            min="0.1"
+                            step="0.1"
+                            value="1">
                         <div id="segmentInfo" class="segment-info"></div>
                     </div>
                     <canvas id="polygonCanvas"></canvas>


### PR DESCRIPTION
## Summary
- Allow custom scale for polygon drawings and convert the area to square meters
- Skip width/height validation when polygon data exists and use polygon-based beam and panel calculations
- Compute beam and form panel requirements using polygon edges instead of fixed rectangle dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6890bd6688508326a65793d816b94a5f