### PR TITLE
Add scalable drawing measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,16 @@ Kullanıcılar:
 
 ### 🧭 Arayüz Özellikleri
 
-- **🚶‍♂️ Adım Adım Kullanım Akışı**  
+- **🚶‍♂️ Adım Adım Kullanım Akışı**
   Panel girişinden sonuçlara kadar yönlendirici yapı.
 
-- **✅ Gerçek Zamanlı Doğrulama**  
+- **✅ Gerçek Zamanlı Doğrulama**
   Hatalı girişler anında kullanıcıya bildirilir.
 
-- **🔔 Toast Bildirim Sistemi**  
+- **📏 Ölçekli Çizim Desteği**
+  Piksel ölçüleri gerçek metre ve m² değerlerine dönüştürülür. Ölçek kullanıcı tarafından girilebilir veya alan ölçülerinden otomatik hesaplanabilir.
+
+- **🔔 Toast Bildirim Sistemi**
   Başarılı işlemler, hatalar vb. için rahatsız etmeyen bildirimler.
 
 - **📭 Boş Durum Yönetimi**  

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
                         <button id="addPointBtn" class="btn btn-secondary">Nokta Ekle</button>
                         <button id="finishDrawingBtn" class="btn btn-secondary">Çizimi Bitir</button>
                         <button id="confirmPolygonBtn" class="btn btn-primary" style="display: none;">Tamam</button>
+                        <button id="autoScaleBtn" class="btn btn-secondary">Ölçeği Hesapla</button>
                         <input
                             type="number"
                             id="drawingScale"


### PR DESCRIPTION
## Summary
- allow user-specified or auto-calculated drawing scale
- display polygon segment lengths and areas in meters/m²
- document new scaling feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c131b3b88326a25daa37aae868f4