### PR TITLE
feat: add numeric/drawing toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,26 +44,32 @@
                 <h2><i class="fas fa-ruler-combined"></i> İnşaat Alanı</h2>
 
                 <div class="area-form">
-                    <div class="input-group">
-                        <input type="number" id="areaWidth" placeholder="Genişlik (m)" min="0.1" step="0.1">
-                        <span class="input-separator">×</span>
-                        <input type="number" id="areaHeight" placeholder="Yükseklik (m)" min="0.1" step="0.1">
+                    <div class="mode-toggle">
+                        <label><input type="radio" name="areaMode" id="modeNumeric" value="numeric" checked> Ölçü gir</label>
+                        <label><input type="radio" name="areaMode" id="modeDrawing" value="drawing"> Çizim yap</label>
                     </div>
+                    <div class="numeric-area">
+                        <div class="input-group">
+                            <input type="number" id="areaWidth" placeholder="Genişlik (m) (opsiyonel)" min="0.1" step="0.1">
+                            <span class="input-separator">×</span>
+                            <input type="number" id="areaHeight" placeholder="Yükseklik (m) (opsiyonel)" min="0.1" step="0.1">
+                        </div>
 
-                    <div class="options">
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="allowRotation" checked>
-                            <span class="checkmark"></span>
-                            Kalıpların dönmesine izin ver (90°)
-                        </label>
+                        <div class="options">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="allowRotation" checked>
+                                <span class="checkmark"></span>
+                                Kalıpların dönmesine izin ver (90°)
+                            </label>
+                        </div>
+
+                        <button id="calculateBtn" class="btn btn-success">
+                            <i class="fas fa-calculator"></i> Yerleştirmeyi Hesapla
+                        </button>
                     </div>
-
-                    <button id="calculateBtn" class="btn btn-success">
-                        <i class="fas fa-calculator"></i> Yerleştirmeyi Hesapla
-                    </button>
                 </div>
 
-                <div class="polygon-drawing">
+                <div class="polygon-drawing" style="display: none;">
                     <div class="drawing-controls">
                         <button id="addPointBtn" class="btn btn-secondary">Nokta Ekle</button>
                         <button id="finishDrawingBtn" class="btn btn-secondary">Çizimi Bitir</button>

--- a/script.js
+++ b/script.js
@@ -34,6 +34,10 @@ class PanelPlacementApp {
             areaHeight: document.getElementById('areaHeight'),
             allowRotation: document.getElementById('allowRotation'),
             calculateBtn: document.getElementById('calculateBtn'),
+            modeNumeric: document.getElementById('modeNumeric'),
+            modeDrawing: document.getElementById('modeDrawing'),
+            numericArea: document.querySelector('.numeric-area'),
+            polygonDrawing: document.querySelector('.polygon-drawing'),
             resultsSection: document.getElementById('resultsSection'),
             usedPanelsCount: document.getElementById('usedPanelsCount'),
             remainingArea: document.getElementById('remainingArea'),
@@ -81,11 +85,16 @@ class PanelPlacementApp {
             if (e.key === 'Enter') this.calculatePlacement();
         });
 
+        // Alan modu değişimi
+        this.elements.modeNumeric.addEventListener('change', () => this.toggleAreaMode());
+        this.elements.modeDrawing.addEventListener('change', () => this.toggleAreaMode());
+
         // Canvas'ı ayarla
         this.canvas = this.elements.visualizationCanvas;
         this.ctx = this.canvas.getContext('2d');
 
         this.initPolygonDrawing();
+        this.toggleAreaMode();
     }
 
     initPolygonDrawing() {
@@ -180,6 +189,16 @@ class PanelPlacementApp {
             this.polygonCtx.arc(pt.x, pt.y, 3, 0, Math.PI * 2);
             this.polygonCtx.fill();
         });
+    }
+
+    toggleAreaMode() {
+        if (this.elements.modeDrawing.checked) {
+            this.elements.numericArea.style.display = 'none';
+            this.elements.polygonDrawing.style.display = '';
+        } else {
+            this.elements.numericArea.style.display = '';
+            this.elements.polygonDrawing.style.display = 'none';
+        }
     }
 
     addPolygonPoint(x, y) {

--- a/style.css
+++ b/style.css
@@ -97,6 +97,18 @@ input[type="number"]:focus {
     color: #6c757d;
 }
 
+.mode-toggle {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
+.mode-toggle label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 /* Button Stili */
 .btn {
     padding: 12px 20px;


### PR DESCRIPTION
## Summary
- mark area dimensions as optional and wrap them in a new `numeric-area` container
- add radio-based toggle between numeric entry and polygon drawing
- implement JS to show and hide numeric inputs or polygon controls based on selected mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c65c5744832695f82f2154444ed4