### PR TITLE
Allow polygon scale from known measurements

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,18 @@
                             min="0.1"
                             step="0.1"
                             value="1">
+                        <input
+                            type="number"
+                            id="knownEdge"
+                            placeholder="Bilinen Kenar (m)"
+                            min="0.1"
+                            step="0.1">
+                        <input
+                            type="number"
+                            id="knownArea"
+                            placeholder="Toplam Alan (m²)"
+                            min="0.1"
+                            step="0.1">
                         <div id="segmentInfo" class="segment-info"></div>
                     </div>
                     <canvas id="polygonCanvas"></canvas>


### PR DESCRIPTION
## Summary
- Skip width/height validation when a polygon exists and compute scale using any provided dimensions
- Support scale calculation from a known polygon edge or total area and update UI to capture these values
- Notify users when no measurements are provided for scale

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890ce3a123c8326aac0ddb9ddf52fec