### PR TITLE
Add polygon reset control and guard numeric parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,10 @@
                             </label>
                         </div>
 
+                        <button id="resetPolygonBtn" class="btn btn-danger" style="display: none; width: 100%; margin-top: 10px;">
+                            <i class="fas fa-trash"></i> Çizimi Sıfırla
+                        </button>
+
                         <button id="calculateBtn" class="btn btn-success">
                             <i class="fas fa-calculator"></i> Yerleştirmeyi Hesapla
                         </button>

--- a/script.js
+++ b/script.js
@@ -34,6 +34,7 @@ class PanelPlacementApp {
             areaHeight: document.getElementById('areaHeight'),
             allowRotation: document.getElementById('allowRotation'),
             calculateBtn: document.getElementById('calculateBtn'),
+            resetPolygonBtn: document.getElementById('resetPolygonBtn'),
             modeNumeric: document.getElementById('modeNumeric'),
             modeDrawing: document.getElementById('modeDrawing'),
             numericArea: document.querySelector('.numeric-area'),
@@ -61,6 +62,14 @@ class PanelPlacementApp {
         // Event listener'ları ekle
         this.elements.addPanelBtn.addEventListener('click', () => this.addPanel());
         this.elements.calculateBtn.addEventListener('click', () => this.calculatePlacement());
+        this.elements.resetPolygonBtn.addEventListener('click', () => {
+            this.polygonPoints = [];
+            if (this.polygonCtx) {
+                this.polygonCtx.clearRect(0, 0, this.polygonCanvas.width, this.polygonCanvas.height);
+            }
+            this.showToast('Çizim sıfırlandı!', 'success');
+            this.toggleAreaMode();
+        });
         this.elements.exportBtn.addEventListener('click', () => this.exportCanvas());
         this.elements.autoScaleBtn.addEventListener('click', () => this.autoCalculateScale());
         this.elements.drawingScale.addEventListener('input', () => {
@@ -197,9 +206,16 @@ class PanelPlacementApp {
         if (this.elements.modeDrawing.checked) {
             this.elements.numericArea.style.display = 'none';
             this.elements.polygonDrawing.style.display = '';
+            this.elements.resetPolygonBtn.style.display = 'none';
         } else {
             this.elements.numericArea.style.display = '';
             this.elements.polygonDrawing.style.display = 'none';
+            if (this.polygonPoints.length > 0) {
+                this.elements.resetPolygonBtn.style.display = '';
+                this.showToast('Çizim mevcut. Sayısal giriş için önce çizimi sıfırlayın.', 'warning');
+            } else {
+                this.elements.resetPolygonBtn.style.display = 'none';
+            }
         }
     }
 
@@ -418,11 +434,13 @@ class PanelPlacementApp {
 
         const polygonDefined = this.polygonPoints && this.polygonPoints.length > 0;
 
-        const areaWidth = parseFloat(this.elements.areaWidth.value);
-        const areaHeight = parseFloat(this.elements.areaHeight.value);
+        const areaWidthVal = this.elements.areaWidth.value;
+        const areaHeightVal = this.elements.areaHeight.value;
+        const areaWidth = polygonDefined ? null : parseFloat(areaWidthVal);
+        const areaHeight = polygonDefined ? null : parseFloat(areaHeightVal);
 
         if (!polygonDefined) {
-            if (!areaWidth || !areaHeight || areaWidth <= 0 || areaHeight <= 0) {
+            if (!areaWidthVal || !areaHeightVal || areaWidth <= 0 || areaHeight <= 0) {
                 this.showToast('Lütfen geçerli alan boyutları girin!', 'error');
                 return;
             }


### PR DESCRIPTION
## Summary
- Skip parsing numeric area inputs when a polygon is already defined
- Add "Çizimi Sıfırla" button to clear polygon points when returning to numeric mode
- Warn users to reset polygons before entering numeric dimensions

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d19adc188326baaf80af9886a0bc