### PR TITLE
Enable calculation from drawing mode with results toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
                             placeholder="Toplam Alan (m²)"
                             min="0.1"
                             step="0.1">
+                        <button id="calculateDrawingBtn" class="btn btn-success">Yerleştirmeyi Hesapla</button>
                         <div id="segmentInfo" class="segment-info"></div>
                     </div>
                     <canvas id="polygonCanvas"></canvas>

--- a/script.js
+++ b/script.js
@@ -56,7 +56,8 @@ class PanelPlacementApp {
             segmentInfo: document.getElementById('segmentInfo'),
             drawingScale: document.getElementById('drawingScale'),
             knownEdge: document.getElementById('knownEdge'),
-            knownArea: document.getElementById('knownArea')
+            knownArea: document.getElementById('knownArea'),
+            calculateDrawingBtn: document.getElementById('calculateDrawingBtn')
         };
 
         // Event listener'ları ekle
@@ -72,6 +73,13 @@ class PanelPlacementApp {
         });
         this.elements.exportBtn.addEventListener('click', () => this.exportCanvas());
         this.elements.autoScaleBtn.addEventListener('click', () => this.autoCalculateScale());
+        this.elements.calculateDrawingBtn.addEventListener('click', () => {
+            if (this.elements.resultsSection.style.display === 'block') {
+                this.elements.resultsSection.style.display = 'none';
+            } else {
+                this.calculatePlacement();
+            }
+        });
         this.elements.drawingScale.addEventListener('input', () => {
             const val = parseFloat(this.elements.drawingScale.value);
             if (val > 0) this.scaleFactor = val;


### PR DESCRIPTION
## Summary
- Add "Yerleştirmeyi Hesapla" button to the drawing controls in `index.html`
- Map `calculateDrawingBtn` and attach click handler in `init()` to toggle results and invoke `calculatePlacement`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689132ab38408326a048d875be2ae694